### PR TITLE
feat: remove ecs agent log level, enable prom metrics

### DIFF
--- a/modules/mixins/ecs-agent/default.nix
+++ b/modules/mixins/ecs-agent/default.nix
@@ -19,8 +19,8 @@
     image = "public.ecr.aws/ecs/amazon-ecs-agent:v1.82.3";
 
     ports = [
-      "127.0.0.1:51678:51678" # ecs metadata service
-      "127.0.0.1:51680:51680" # prometheus metrics
+      "51678:51678" # ecs metadata service
+      "51680:51680" # prometheus metrics
     ];
 
     extraOptions = [
@@ -29,7 +29,7 @@
 
     environmentFiles = ["/run/keys/ecs.config"];
     environment = {
-      ECS_LOGFILE = "/log/ecs-agent.log";
+      ECS_ENABLE_PROMETHEUS_METRICS = "true";
       ECS_LOGLEVEL = "info";
       ECS_DATADIR = "/data";
       ECS_UPDATES_ENABLED = "false";


### PR DESCRIPTION
## Changes

- Removes the ECS agent's `LOGFILE` configuration to prevent it writing. We already collect its logs in journald.
- Enables Prometheus metrics on the agent for Alloy to scrape