### PR TITLE
GitHub Actions updates

### DIFF
--- a/modules/mixins/github-actions/default.nix
+++ b/modules/mixins/github-actions/default.nix
@@ -1,9 +1,6 @@
 # GitHub Actions runner mixin
 # In theory, compatible with x86_64-linux and aarch64-linux.
 { pkgs, ... }:
-let
-  name = "altf4llc-${pkgs.stdenv.system}";
-in
 {
   imports = [
     ../alloy
@@ -27,10 +24,10 @@ in
     group = "github-runner";
     extraGroups = [ "docker" ];
     isNormalUser = true;
-    home = "/run/github-runner/${name}";
+    home = "/run/github-runner/runner";
   };
 
-  services.github-runners.${name} = {
+  services.github-runners.runner = {
     enable = true;
     name = null;
     url = "https://github.com/ALT-F4-LLC";

--- a/modules/mixins/github-actions/default.nix
+++ b/modules/mixins/github-actions/default.nix
@@ -32,6 +32,7 @@ in
 
   services.github-runners.${name} = {
     enable = true;
+    name = null;
     url = "https://github.com/ALT-F4-LLC";
     user = "github-runner";
     tokenFile = "/run/keys/github-runner";


### PR DESCRIPTION
## Changes

- Use the runner's instance hostname as the actions runner name, instead of hardcoding to `altf4llc-<system>`.