### PR TITLE
Alloy configuration updates

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -16,24 +16,6 @@
         "type": "indirect"
       }
     },
-    "flake-parts_2": {
-      "inputs": {
-        "nixpkgs-lib": "nixpkgs-lib_2"
-      },
-      "locked": {
-        "lastModified": 1715865404,
-        "narHash": "sha256-/GJvTdTpuDjNn84j82cU6bXztE0MSkdnTWClUCRub78=",
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "rev": "8dc45382d5206bd292f9c2768b8058a8fd8311d9",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "type": "github"
-      }
-    },
     "nixlib": {
       "locked": {
         "lastModified": 1712450863,
@@ -104,45 +86,11 @@
         "type": "github"
       }
     },
-    "nixpkgs-lib_2": {
-      "locked": {
-        "lastModified": 1714640452,
-        "narHash": "sha256-QBx10+k6JWz6u7VsohfSw8g8hjdBZEf8CFzXH1/1Z94=",
-        "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/50eb7ecf4cd0a5756d7275c8ba36790e5bd53e33.tar.gz"
-      },
-      "original": {
-        "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/50eb7ecf4cd0a5756d7275c8ba36790e5bd53e33.tar.gz"
-      }
-    },
-    "pkgs-nix": {
-      "inputs": {
-        "flake-parts": "flake-parts_2",
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1717279556,
-        "narHash": "sha256-msDwm0MHE+zvAfuWXtTBVR4PQhnI/MU9XQzx+4LbUP0=",
-        "owner": "ALT-F4-LLC",
-        "repo": "pkgs.nix",
-        "rev": "3143fc567c8d82edadda31efe90ccc5c2d5d5c64",
-        "type": "github"
-      },
-      "original": {
-        "owner": "ALT-F4-LLC",
-        "repo": "pkgs.nix",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "flake-parts": "flake-parts",
         "nixos-generators": "nixos-generators",
         "nixpkgs": "nixpkgs",
-        "pkgs-nix": "pkgs-nix",
         "srvos": "srvos"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -39,11 +39,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1716210724,
-        "narHash": "sha256-iqQa3omRcHGpWb1ds75jS9ruA5R39FTmAkeR3J+ve1w=",
+        "lastModified": 1718025593,
+        "narHash": "sha256-WZ1gdKq/9u1Ns/oXuNsDm+W0salonVA0VY1amw8urJ4=",
         "owner": "nix-community",
         "repo": "nixos-generators",
-        "rev": "d14b286322c7f4f897ca4b1726ce38cb68596c94",
+        "rev": "35c20ba421dfa5059e20e0ef2343c875372bdcf3",
         "type": "github"
       },
       "original": {
@@ -54,11 +54,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1716948383,
-        "narHash": "sha256-SzDKxseEcHR5KzPXLwsemyTR/kaM9whxeiJohbL04rs=",
+        "lastModified": 1718318537,
+        "narHash": "sha256-4Zu0RYRcAY/VWuu6awwq4opuiD//ahpc2aFHg2CWqFY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ad57eef4ef0659193044870c731987a6df5cf56b",
+        "rev": "e9ee548d90ff586a6471b4ae80ae9cfcbceb3420",
         "type": "github"
       },
       "original": {
@@ -101,11 +101,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1717058062,
-        "narHash": "sha256-R8Gb2MlJzfBE76DVWFmfZWODMdAanqxFnK+OOmkoQ7E=",
+        "lastModified": 1718459800,
+        "narHash": "sha256-oRkHJbp/jIljo+yXY6sSjMMTBqWNhIjd4qhs0pTjwbs=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "414d1039a58b667e4512ad9f7068aa935ebf8d59",
+        "rev": "b724a9ad24945a4d6fb11a42f1c2ce072fa3c4c2",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -7,9 +7,6 @@
 
     srvos.url = "github:nix-community/srvos";
     srvos.inputs.nixpkgs.follows = "nixpkgs";
-
-    pkgs-nix.url = "github:ALT-F4-LLC/pkgs.nix";
-    pkgs-nix.inputs.nixpkgs.follows = "nixpkgs";
   };
 
   outputs = inputs @ {flake-parts, ...}:

--- a/modules/mixins/alloy-forwarder/config.alloy
+++ b/modules/mixins/alloy-forwarder/config.alloy
@@ -20,12 +20,21 @@ prometheus.receive_http "forward" {
   ]
 }
 
-prometheus.scrape "linux_node" {
-  targets = prometheus.exporter.unix.node.targets
-  forward_to = [ grafana_cloud.stack.receivers.metrics ]
+// Set instance label to the hostname
+prometheus.relabel "instance" {
+  forward_to = [grafana_cloud.stack.receivers.metrics]
+  rule {
+    target_label = "instance"
+    replacement  = local.file.hostname.content
+  }
 }
 
 prometheus.exporter.unix "node" {
+}
+
+prometheus.scrape "linux_node" {
+  targets = prometheus.exporter.unix.node.targets
+  forward_to = [prometheus.relabel.instance.receiver]
 }
 
 prometheus.exporter.self "agent" {
@@ -33,7 +42,7 @@ prometheus.exporter.self "agent" {
 
 prometheus.scrape "agent" {
   targets = prometheus.exporter.self.agent.targets
-  forward_to = [ grafana_cloud.stack.receivers.metrics ]
+  forward_to = [prometheus.relabel.instance.receiver]
 }
 
 loki.source.api "receive" {
@@ -46,45 +55,21 @@ loki.source.api "receive" {
     ]
 }
 
-loki.relabel "journal" {
-  forward_to = []
-
-  rule {
-    source_labels = ["__journal__systemd_unit"]
-    target_label  = "unit"
-  }
-  rule {
-    source_labels = ["__journal__boot_id"]
-    target_label  = "boot_id"
-  }
-  rule {
-    source_labels = ["__journal__transport"]
-    target_label  = "transport"
-  }
-  rule {
-    source_labels = ["__journal_priority_keyword"]
-    target_label  = "level"
-  }
-  rule {
-    source_labels = ["__journal__hostname"]
-    target_label  = "instance"
-  }
-}
-
 loki.source.journal "read" {
   forward_to = [
     grafana_cloud.stack.receivers.logs,
   ]
-  relabel_rules = loki.relabel.journal.rules
+  relabel_rules = concat(
+    loki.relabel.journal.rules,
+    loki.relabel.instance.rules,
+  )
   labels = {
     "job" = "integrations/node_exporter",
   }
 }
 
 otelcol.exporter.prometheus "to_prometheus" {
-  forward_to = [
-    grafana_cloud.stack.receivers.metrics,
-  ]
+  forward_to = [grafana_cloud.stack.receivers.metrics]
 }
 
 otelcol.exporter.loki "to_loki" {

--- a/modules/mixins/alloy-forwarder/default.nix
+++ b/modules/mixins/alloy-forwarder/default.nix
@@ -15,12 +15,9 @@
     4317 # OTLP/gRPC
   ];
 
-  services.alloy = {
-    extraArgs = "--stability.level public-preview";
-
-    environmentFiles = [ "/run/keys/grafana-cloud" ];
-    extraEnvironment = {
-      GRAFANA_CLOUD_STACK = "altf4llc";
-    };
+  services.alloy.extraFlags = ["--stability.level=public-preview"];
+  systemd.services.alloy.serviceConfig.EnvironmentFile = [ "/run/keys/grafana-cloud" ];
+  systemd.services.alloy.environment = {
+    GRAFANA_CLOUD_STACK = "altf4llc";
   };
 }

--- a/modules/mixins/alloy/base.alloy
+++ b/modules/mixins/alloy/base.alloy
@@ -1,0 +1,56 @@
+// Grab hostname from /etc instead of environment variables
+local.file "hostname" {
+  filename = "/etc/hostname"
+}
+
+// Set hostname from /etc
+loki.relabel "instance" {
+  forward_to = []
+
+  rule {
+    target_label = "instance"
+    replacement  = local.file.hostname.content
+  }
+}
+
+// Loki journal relabeller
+loki.relabel "journal" {
+  forward_to = []
+
+  rule {
+    source_labels = ["__journal__systemd_unit"]
+    target_label  = "unit"
+  }
+
+  rule {
+    source_labels = ["__journal__boot_id"]
+    target_label  = "boot_id"
+  }
+
+  rule {
+    source_labels = ["__journal__transport"]
+    target_label  = "transport"
+  }
+
+  rule {
+    source_labels = ["__journal_priority_keyword"]
+    target_label  = "level"
+  }
+
+  rule {
+    source_labels = ["__journal_container_name"]
+    target_label  = "container_name"
+  }
+
+  rule {
+    source_labels = ["__journal_image_name"]
+    target_label  = "container_image"
+  }
+
+  rule {
+    source_labels = ["__journal_container_id"]
+    target_label  = "container_id"
+  }
+}
+
+// vim:ft=hcl

--- a/modules/mixins/alloy/config.alloy
+++ b/modules/mixins/alloy/config.alloy
@@ -64,7 +64,7 @@ prometheus.relabel "instance" {
   forward_to = [otelcol.receiver.prometheus.default.receiver]
   rule {
     target_label = "instance"
-    replacement  = env("HOSTNAME")
+    replacement  = local.file.hostname.content
   }
 }
 

--- a/modules/mixins/alloy/default.nix
+++ b/modules/mixins/alloy/default.nix
@@ -1,18 +1,15 @@
-{ pkgs-nix, pkgs, ... }: {
-  imports = [ pkgs-nix.nixosModules.alloy ];
-
+{ ... }: {
   environment.etc."alloy/config.alloy" = {
     source = ./config.alloy;
     mode = "0440";
     user = "root";
   };
 
-  services.alloy = {
-    enable = true;
-    package = pkgs-nix.packages.${pkgs.system}.alloy;
-    openFirewall = true;
-    configPath = "/etc/alloy";
-    group = "root";
+  environment.etc."alloy/base.alloy" = {
+    source = ./base.alloy;
+    mode = "0440";
     user = "root";
   };
+
+  services.alloy.enable = true;
 }


### PR DESCRIPTION
## Changes

- Switches from our homebrew `alloy` package to the upstream nixpkgs `grafana-alloy` package and `services.alloy` module
- Configures the instance hostname using `/etc/hostname` instead of `env("HOSTNAME")`, as `$HOSTNAME` is not set on NixOS seemingly
- Configures a shared journald relabel and shared loki instance labeller in our configuration