### PR TITLE
fix: pass hostname through a trim filter before shipping

### DIFF
--- a/modules/mixins/alloy-forwarder/config.alloy
+++ b/modules/mixins/alloy-forwarder/config.alloy
@@ -25,7 +25,7 @@ prometheus.relabel "instance" {
   forward_to = [grafana_cloud.stack.receivers.metrics]
   rule {
     target_label = "instance"
-    replacement  = local.file.hostname.content
+    replacement  = trim_space(local.file.hostname.content)
   }
 }
 

--- a/modules/mixins/alloy/base.alloy
+++ b/modules/mixins/alloy/base.alloy
@@ -9,7 +9,7 @@ loki.relabel "omnibus" {
 
   rule {
     target_label = "instance"
-    replacement  = local.file.hostname.content
+    replacement  = trim_space(local.file.hostname.content)
   }
 
   rule {

--- a/modules/mixins/alloy/config.alloy
+++ b/modules/mixins/alloy/config.alloy
@@ -27,31 +27,6 @@ otelcol.receiver.loki "default" {
   }
 }
 
-// Extract Systemd unit from journal entry
-loki.relabel "journal" {
-  forward_to = []
-
-  rule {
-    target_label = "instance"
-    replacement  = local.file.hostname.content
-  }
-
-  rule {
-    source_labels = ["__journal__systemd_unit"]
-    target_label  = "unit"
-  }
-
-  rule {
-    source_labels = ["__journal__boot_id"]
-    target_label  = "boot_id"
-  }
-
-  rule {
-    source_labels = ["__journal__transport"]
-    target_label  = "transport"
-  }
-}
-
 // Fetch journal entries
 loki.source.journal "journal" {
   forward_to    = [otelcol.receiver.loki.default.receiver]
@@ -64,7 +39,7 @@ prometheus.relabel "instance" {
   forward_to = [otelcol.receiver.prometheus.default.receiver]
   rule {
     target_label = "instance"
-    replacement  = local.file.hostname.content
+    replacement  = trim_space(local.file.hostname.content)
   }
 }
 


### PR DESCRIPTION
## Changes

- Passes all `instance` labels using `/etc/hostname` as a source through the `trim_space` function to fix query errors, as `/etc/hostname` has a newline char at the end of it.

Source for help on the issue is Grafana Cloud support;

you will see the instance name is trailed by a " " which when replaced in the $instance variable causes the query payload to have a line break. 
```
topk(25,irate(node_disk_io_time_seconds_total{job=~"integrations/(node_exporter|unix)",cluster=~".*",job=~".+",instance=~"ip-10-0-34-226
", device!=""}[4m0s]))
```

(Note that the `"` is on line two of the query, not on the end of line one)